### PR TITLE
Update paytm.php

### DIFF
--- a/Opencart_V2.0.x/opencart 2.0/catalog/controller/payment/paytm.php
+++ b/Opencart_V2.0.x/opencart 2.0/catalog/controller/payment/paytm.php
@@ -155,7 +155,11 @@ class ControllerPaymentpaytm extends Controller {
 				
 			} else {
 				$this->load->model('checkout/order');
-
+				//Enabling new order id to be generated after a failed transaction
+					if (isset($this->session->data['order_id'])) {
+					unset($this->session->data['order_id']);			
+					}							
+				
 				$data['continue'] = $this->url->link('checkout/cart');
 				if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/paytm_failure.tpl')) {
 					$this->template = $this->config->get('config_template') . '/template/payment/paytm_failure.tpl';


### PR DESCRIPTION
Since Paytm won't accept duplicate order ids and opencart won't change order id for a single session until successful transaction, so i had to make sure that if a transaction is failed on paytm a new order id must be generated enabling the customer to try making the payment again.